### PR TITLE
Duplicate to another course not updating external URLs in URL activities

### DIFF
--- a/classes/actions.php
+++ b/classes/actions.php
@@ -326,7 +326,10 @@ class actions {
             }
         }
 
+        // Sort the selected modules into the order they appear in the source course, so duplicates
+        // land in the target course in the same relative order.
         $idsincourseorder = self::sort_course_order($modules);
+
         // We now duplicate the modules in the order they have in the course. That way the duplicated modules will be correctly
         // sorted by their id:
         // Let order of mods in a section be mod1, mod2, mod3, mod4, mod5. If we duplicate mod2, mod4, the order afterwards will be
@@ -334,6 +337,7 @@ class actions {
         $duplicatedmods = [];
         $cms = [];
         $errors = [];
+
         $filtersectionshook = new filter_sections_same_course($sourcecourseid, array_keys($sourcemodinfo->get_section_info_all()));
         \core\di::get(\core\hook\manager::class)->dispatch($filtersectionshook);
         $srcfilteredsections = $filtersectionshook->get_sectionnums();
@@ -346,6 +350,9 @@ class actions {
             }
 
             try {
+                // Each activity is restored individually, so the restore pipeline's link-decoder cannot rewrite
+                // URL activities that link to other activities in the same batch. We handle that ourselves via
+                // rewrite_url_cm_references() further below after all activities have been duplicated.
                 $duplicatedmod = massactionutils::duplicate_cm_to_course($targetmodinfo->get_course(),
                     $sourcemodinfo->get_cm($cmid));
             } catch (\Exception $e) {
@@ -360,19 +367,28 @@ class actions {
                 $event->trigger();
                 continue;
             }
+
             $cms[$cmid] = $duplicatedmod;
             $duplicatedmods[] = $duplicatedmod;
         }
 
-        // We need to reload new course structure.
+        // Reload the target course structure — the duplicated modules did not exist when
+        // $targetmodinfo was first loaded. We need a fresh copy here for the moveto_module() calls below.
         $targetmodinfo = get_fast_modinfo($targetcourseid);
         $targetsection = $targetmodinfo->get_section_info($sectionnum);
+
         if ($sectionnum != -1) {
             // A target section has been specified, so we have to move the course modules.
             foreach ($duplicatedmods as $modid) {
                 moveto_module($targetmodinfo->get_cm($modid), $targetsection);
             }
         }
+
+        // Now that all activities have been duplicated and we have a complete old => new CMID
+        // map in $cms, rewrite any URL activities in the target course whose externalurl still
+        // references a CMID from the source course.
+        self::rewrite_url_cm_references($cms, $targetcourseid);
+
         $event = \block_massaction\event\course_modules_duplicated::create([
             'context' => \context_course::instance($sourcecourseid),
             'other' => [
@@ -662,5 +678,57 @@ class actions {
         });
 
         return $idsincourseorder;
+    }
+
+    /**
+     * Rewrites externalurl fields in URL activities where those URLs reference CMIDs that
+     * have been remapped (e.g. after duplicating or restoring activities to another course).
+     *
+     * When activities are backed up and restored one at a time, each restore operation is
+     * isolated and has no knowledge of CMIDs created by other restore operations in the same
+     * batch. This means the restore pipeline's own link-decoder cannot fix cross-activity
+     * links. This method solves that by applying the rewrite manually using a caller-supplied
+     * CMID map.
+     *
+     * This method is intentionally general-purpose: it can be used anywhere a batch of
+     * activities has been copied or restored and a CMID map is available.
+     *
+     * @param array $cmidmap Map of old CMID => new CMID for the activities in this batch.
+     * @param int $courseid The course ID containing the URL activities to be rewritten.
+     * @throws dml_exception if the database read or write fails.
+     */
+    public static function rewrite_url_cm_references(array $cmidmap, int $courseid): void {
+        global $DB;
+
+        if (empty($cmidmap)) {
+            return;
+        }
+
+        // Load the course structure fresh, to make sure any recently
+        // created modules appear in the cached modinfo.
+        $modinfo = get_fast_modinfo($courseid);
+
+        // Check every new CMID in the map — only URL activities need rewriting.
+        foreach (array_values($cmidmap) as $cmid) {
+            $cm = $modinfo->get_cm($cmid);
+            if ($cm->modname !== 'url') {
+                continue;
+            }
+            $urlrecord = $DB->get_record('url', ['id' => $cm->instance], '*', MUST_EXIST);
+            $originalurl = $urlrecord->externalurl;
+            foreach ($cmidmap as $oldcmid => $replacementcmid) {
+                // Use a word boundary (\b) to avoid partial matches,
+                // e.g. preventing id=12 from matching inside id=123.
+                $urlrecord->externalurl = preg_replace(
+                    '/\bid=' . preg_quote($oldcmid, '/') . '\b/',
+                    'id=' . $replacementcmid,
+                    $urlrecord->externalurl
+                );
+            }
+            // Only write to the database if the URL actually changed.
+            if ($urlrecord->externalurl !== $originalurl) {
+                $DB->update_record('url', $urlrecord);
+            }
+        }
     }
 }

--- a/tests/massaction_test.php
+++ b/tests/massaction_test.php
@@ -31,6 +31,7 @@ use require_login_exception;
 use restore_controller_exception;
 use stdClass;
 
+
 /**
  * block_massaction phpunit test class.
  *
@@ -961,5 +962,132 @@ final class massaction_test extends advanced_testcase {
 
         // The names of the duplicated modules should be the same as the source module names.
         $this->assertEquals($sourcemodulenames, $duplicatedmodulenames);
+    }
+
+    /**
+     * Tests that URL activities have their externalurl rewritten when duplicating to another course.
+     * Specifically, a URL pointing at an assignment in the source course should point at the
+     * newly duplicated assignment in the target course after duplication.
+     *
+     * @covers \block_massaction\actions::duplicate_to_course
+     * @return void
+     * @throws base_plan_exception
+     * @throws base_setting_exception
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws moodle_exception
+     * @throws restore_controller_exception
+     */
+    public function test_duplicate_to_course_rewrites_url_references(): void {
+        global $DB, $CFG;
+
+        $generator = $this->getDataGenerator();
+        $sourcecourseid = $this->course->id;
+
+        // Create an assignment in the source course.
+        $assign = $generator->create_module('assign', ['course' => $sourcecourseid], ['section' => 0]);
+        $assigncm = get_coursemodule_from_instance('assign', $assign->id, $sourcecourseid);
+
+        // Create a URL activity that points at the assignment via its CMID.
+        $externalurl = $CFG->wwwroot . '/mod/assign/view.php?id=' . $assigncm->id;
+        $url = $generator->create_module('url', ['course' => $sourcecourseid, 'externalurl' => $externalurl], ['section' => 0]);
+        $urlcm = get_coursemodule_from_instance('url', $url->id, $sourcecourseid);
+
+        // Set up a target course.
+        $targetcourseid = $this->setup_target_course_for_duplicating(1);
+
+        // Duplicate both the assignment and the URL to the target course.
+        $modules = $DB->get_records_select('course_modules', 'id IN (?, ?)', [$assigncm->id, $urlcm->id]);
+        block_massaction\actions::duplicate_to_course($modules, $targetcourseid);
+
+        // Find the newly duplicated assignment and URL in the target course.
+        $targetmodinfo = get_fast_modinfo($targetcourseid);
+        $targetassigns = $targetmodinfo->get_instances_of('assign');
+        $targeturls = $targetmodinfo->get_instances_of('url');
+
+        // There should be exactly one duplicated assignment and one duplicated URL.
+        $this->assertCount(1, $targetassigns);
+        $this->assertCount(1, $targeturls);
+
+        $newassigncm = reset($targetassigns);
+        $newurlcm = reset($targeturls);
+
+        // The URL in the target course should point at the new assignment CMID, not the original.
+        $newurlrecord = $DB->get_record('url', ['id' => $newurlcm->instance], '*', MUST_EXIST);
+        $expectedurl = $CFG->wwwroot . '/mod/assign/view.php?id=' . $newassigncm->id;
+        $this->assertEquals($expectedurl, $newurlrecord->externalurl);
+        $this->assertStringNotContainsString('id=' . $assigncm->id, $newurlrecord->externalurl);
+    }
+
+    /**
+     * Data provider for test_rewrite_url_cm_references.
+     *
+     * @return array
+     */
+    public static function rewrite_url_cm_references_provider(): array {
+        return [
+            'url referencing a cmid in the map is rewritten' => [
+                'urlsuffix' => '?id=100',
+                'oldcmid' => 100,
+                'expectrewrite' => true,
+            ],
+            'url not referencing any cmid in the map is unchanged' => [
+                'urlsuffix' => '?id=999',
+                'oldcmid' => 100,
+                'expectrewrite' => false,
+            ],
+            'partial number match is not rewritten' => [
+                'urlsuffix' => '?id=123',
+                'oldcmid' => 12,
+                'expectrewrite' => false,
+            ],
+            'empty map returns early and nothing is changed' => [
+                'urlsuffix' => '?id=100',
+                'oldcmid' => null,
+                'expectrewrite' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Tests the rewrite_url_cm_references static method directly, covering normal operation
+     * and edge cases.
+     *
+     * @covers \block_massaction\actions::rewrite_url_cm_references
+     * @dataProvider rewrite_url_cm_references_provider
+     * @param string $urlsuffix the query string to append to the base URL
+     * @param int|null $oldcmid the old CMID to put in the map, or null for empty map test
+     * @param bool $expectrewrite whether the URL is expected to be rewritten
+     * @return void
+     * @throws dml_exception
+     * @throws moodle_exception
+     */
+    public function test_rewrite_url_cm_references(string $urlsuffix, ?int $oldcmid, bool $expectrewrite): void {
+        global $DB, $CFG;
+
+        $generator = $this->getDataGenerator();
+        $courseid = $this->course->id;
+
+        // Create a URL activity with the given external URL.
+        $baseurl = $CFG->wwwroot . '/mod/assign/view.php';
+        $url = $generator->create_module('url', [
+            'course' => $courseid,
+            'externalurl' => $baseurl . $urlsuffix,
+        ], ['section' => 0]);
+        $urlcm = get_coursemodule_from_instance('url', $url->id, $courseid);
+
+        // Build the CMID map: empty if oldcmid is null, otherwise map oldcmid to the new URL's CMID.
+        $cmidmap = $oldcmid !== null ? [$oldcmid => $urlcm->id] : [];
+
+        actions::rewrite_url_cm_references($cmidmap, $courseid);
+
+        $urlrecord = $DB->get_record('url', ['id' => $url->id], '*', MUST_EXIST);
+
+        if ($expectrewrite) {
+            $this->assertStringContainsString('id=' . $urlcm->id, $urlrecord->externalurl);
+            $this->assertStringNotContainsString('id=' . $oldcmid, $urlrecord->externalurl);
+        } else {
+            $this->assertEquals($baseurl . $urlsuffix, $urlrecord->externalurl);
+        }
     }
 }

--- a/tests/massaction_test.php
+++ b/tests/massaction_test.php
@@ -1028,22 +1028,22 @@ final class massaction_test extends advanced_testcase {
         return [
             'url referencing a cmid in the map is rewritten' => [
                 'urlsuffix' => '?id=100',
-                'oldcmid' => 100,
+                'dummysourcecmid' => 100,
                 'expectrewrite' => true,
             ],
             'url not referencing any cmid in the map is unchanged' => [
                 'urlsuffix' => '?id=999',
-                'oldcmid' => 100,
+                'dummysourcecmid' => 100,
                 'expectrewrite' => false,
             ],
             'partial number match is not rewritten' => [
                 'urlsuffix' => '?id=123',
-                'oldcmid' => 12,
+                'dummysourcecmid' => 12,
                 'expectrewrite' => false,
             ],
             'empty map returns early and nothing is changed' => [
                 'urlsuffix' => '?id=100',
-                'oldcmid' => null,
+                'dummysourcecmid' => null,
                 'expectrewrite' => false,
             ],
         ];
@@ -1053,40 +1053,64 @@ final class massaction_test extends advanced_testcase {
      * Tests the rewrite_url_cm_references static method directly, covering normal operation
      * and edge cases.
      *
+     * We simulate the scenario of a URL activity that pointed at an assignment in some other
+     * course via its CMID. That other course CMID is a dummy value — it does not correspond
+     * to any real activity in the test database, it simply represents what the CMID would have
+     * looked like in the source course before duplication.
+     *
+     * We create a URL activity whose externalurl contains that dummy source CMID, and an
+     * assignment that represents the newly duplicated activity in the target course. The map
+     * pairs the dummy source CMID with the real CMID of the assignment, simulating the
+     * source => target CMID mapping that would be built during duplication. We then check
+     * whether the URL's externalurl was updated to point at the real assignment or left
+     * alone, depending on what we expect for each scenario.
+     *
      * @covers \block_massaction\actions::rewrite_url_cm_references
      * @dataProvider rewrite_url_cm_references_provider
-     * @param string $urlsuffix the query string to append to the base URL
-     * @param int|null $oldcmid the old CMID to put in the map, or null for empty map test
+     * @param string $urlsuffix the query string to append to the base URL, containing the dummy source CMID
+     * @param int|null $dummysourcecmid a dummy CMID representing an activity in the source course, or null for empty map test
      * @param bool $expectrewrite whether the URL is expected to be rewritten
      * @return void
      * @throws dml_exception
      * @throws moodle_exception
      */
-    public function test_rewrite_url_cm_references(string $urlsuffix, ?int $oldcmid, bool $expectrewrite): void {
+    public function test_rewrite_url_cm_references(string $urlsuffix, ?int $dummysourcecmid, bool $expectrewrite): void {
         global $DB, $CFG;
 
         $generator = $this->getDataGenerator();
         $courseid = $this->course->id;
 
-        // Create a URL activity with the given external URL.
         $baseurl = $CFG->wwwroot . '/mod/assign/view.php';
+
+        // Create an assignment representing the newly duplicated activity in the target course
+        // that the URL should point at after rewriting.
+        $assign = $generator->create_module('assign', ['course' => $courseid], ['section' => 0]);
+        $assigncm = get_coursemodule_from_instance('assign', $assign->id, $courseid);
+
+        // Create a URL activity whose externalurl contains a CMID baked into the URL suffix,
+        // simulating a URL that pointed at an activity in another course before duplication.
+        // Depending on the test case, this CMID may or may not match the dummy source CMID in the map.
         $url = $generator->create_module('url', [
             'course' => $courseid,
             'externalurl' => $baseurl . $urlsuffix,
         ], ['section' => 0]);
-        $urlcm = get_coursemodule_from_instance('url', $url->id, $courseid);
 
-        // Build the CMID map: empty if oldcmid is null, otherwise map oldcmid to the new URL's CMID.
-        $cmidmap = $oldcmid !== null ? [$oldcmid => $urlcm->id] : [];
+        // Build the CMID map: pairs the dummy source CMID with the real CMID of the newly
+        // created assignment, simulating the source => target CMID mapping built during duplication.
+        // Empty if dummysourcecmid is null, to test the early return behaviour.
+        $cmidmap = $dummysourcecmid !== null ? [$dummysourcecmid => $assigncm->id] : [];
 
         actions::rewrite_url_cm_references($cmidmap, $courseid);
 
         $urlrecord = $DB->get_record('url', ['id' => $url->id], '*', MUST_EXIST);
 
         if ($expectrewrite) {
-            $this->assertStringContainsString('id=' . $urlcm->id, $urlrecord->externalurl);
-            $this->assertStringNotContainsString('id=' . $oldcmid, $urlrecord->externalurl);
+            // The URL should now point at the real CMID of the assignment in the target course,
+            // replacing the dummy source CMID that was there before.
+            $this->assertStringContainsString('id=' . $assigncm->id, $urlrecord->externalurl);
+            $this->assertStringNotContainsString('id=' . $dummysourcecmid, $urlrecord->externalurl);
         } else {
+            // The URL should be completely unchanged, still containing the dummy source CMID.
             $this->assertEquals($baseurl . $urlsuffix, $urlrecord->externalurl);
         }
     }


### PR DESCRIPTION
**Scenario**
1. Create an Assignment in a course, and then a URL that points to that assignment.
2. Using Mass Action, select both activities and do 'Duplicate to another course'.
3. After duplication has been made to the other course, the duplicate URL points back to the Assignment in the original course. It should point at the new (duplicate) Assignment.

